### PR TITLE
Treating proto generated files as binary (#73)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.pb.go -diff -merge
+*.pb.go linguist-generated=true


### PR DESCRIPTION
Decided that it's better to keep proto generated files in version control so the repo can be navigated in Github, etc. Instead treat them as binary so they won't show up in diffs and won't have merge conflicts.