### PR TITLE
CLI post and upvotes queries

### DIFF
--- a/x/curating/alias.go
+++ b/x/curating/alias.go
@@ -12,6 +12,8 @@ const (
 	StoreKey          = types.StoreKey
 	DefaultParamspace = types.DefaultParamspace
 	QueryParams       = types.QueryParams
+	QueryPost         = types.QueryPost
+	QueryPosts        = types.QueryPosts
 	QuerierRoute      = types.QuerierRoute
 	RewardPoolName    = types.RewardPoolName
 	VotingPoolName    = types.VotingPoolName

--- a/x/curating/alias.go
+++ b/x/curating/alias.go
@@ -13,7 +13,7 @@ const (
 	DefaultParamspace = types.DefaultParamspace
 	QueryParams       = types.QueryParams
 	QueryPost         = types.QueryPost
-	QueryPosts        = types.QueryPosts
+	QueryUpvotes      = types.QueryUpvotes
 	QuerierRoute      = types.QuerierRoute
 	RewardPoolName    = types.RewardPoolName
 	VotingPoolName    = types.VotingPoolName

--- a/x/curating/client/cli/query.go
+++ b/x/curating/client/cli/query.go
@@ -13,10 +13,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// [TODO]
-// https://github.com/public-awesome/stakebird/issues/57
-// https://github.com/public-awesome/stakebird/issues/58
-
 // GetQueryCmd returns the cli query commands for this module
 func GetQueryCmd(queryRoute string, cdc *codec.Codec) *cobra.Command {
 	// Group stake queries under a subcommand
@@ -32,7 +28,7 @@ func GetQueryCmd(queryRoute string, cdc *codec.Codec) *cobra.Command {
 		flags.GetCommands(
 			GetCmdQueryParams(queryRoute, cdc),
 			GetCmdQueryPost(queryRoute, cdc),
-			GetCmdQueryPosts(queryRoute, cdc),
+			GetCmdQueryUpvotes(queryRoute, cdc),
 		)...,
 	)
 
@@ -90,9 +86,6 @@ $ %s query curating posts 1 123
 			postID := args[1]
 
 			route := fmt.Sprintf("custom/%s/%s/%s/%s", storeName, types.QueryPost, vendorID, postID)
-
-			cliCtx.PrintOutput(route)
-
 			bz, _, err := cliCtx.QueryWithData(route, nil)
 			if err != nil {
 				return err
@@ -105,17 +98,22 @@ $ %s query curating posts 1 123
 	}
 }
 
-// GetCmdQueryPosts implements the posts query command.
-func GetCmdQueryPosts(storeName string, cdc *codec.Codec) *cobra.Command {
+// GetCmdQueryUpvote implements the upvotes query command.
+func GetCmdQueryUpvotes(storeName string, cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
-		Use:   "posts [vendor-id]",
+		Use:   "upvote [vendor-id] [post-id]",
 		Args:  cobra.MinimumNArgs(1),
-		Short: "Query all posts for a given vendor ID",
+		Short: "Query for an upvote by vendor ID and post ID",
 		Long: strings.TrimSpace(
-			fmt.Sprintf(`Query posts for a given vendor ID.
+			fmt.Sprintf(`Query upvote by vendor ID and optionally post ID.
 Example:
-$ %s query curating posts 1
+$ %s query curating upvotes 1 "123"
+
+or...
+
+$ %s query curating upvotes 1
 `,
+				version.ClientName,
 				version.ClientName,
 			),
 		),
@@ -124,15 +122,17 @@ $ %s query curating posts 1
 
 			vendorID := args[0]
 
-			route := fmt.Sprintf("custom/%s/%s/%s", storeName, types.QueryPosts, vendorID)
+			postID := args[1]
+			route := fmt.Sprintf("custom/%s/%s/%s/%s", storeName, types.QueryUpvotes, vendorID, postID)
+
 			bz, _, err := cliCtx.QueryWithData(route, nil)
 			if err != nil {
 				return err
 			}
 
-			var posts []types.Post
-			cdc.MustUnmarshalJSON(bz, &posts)
-			return cliCtx.PrintOutput(posts)
+			var upvote []types.Upvote
+			cdc.MustUnmarshalJSON(bz, &upvote)
+			return cliCtx.PrintOutput(upvote)
 		},
 	}
 }

--- a/x/curating/client/cli/query.go
+++ b/x/curating/client/cli/query.go
@@ -108,12 +108,7 @@ func GetCmdQueryUpvotes(storeName string, cdc *codec.Codec) *cobra.Command {
 			fmt.Sprintf(`Query upvote by vendor ID and optionally post ID.
 Example:
 $ %s query curating upvotes 1 "123"
-
-or...
-
-$ %s query curating upvotes 1
 `,
-				version.ClientName,
 				version.ClientName,
 			),
 		),

--- a/x/curating/keeper/post.go
+++ b/x/curating/keeper/post.go
@@ -195,3 +195,20 @@ func (k Keeper) CurationQueueIterator(
 		types.KeyPrefixCurationQueue,
 		sdk.PrefixEndBytes(types.CurationQueueByTimeKey(endTime)))
 }
+
+func (k Keeper) GetPosts(ctx sdk.Context) []types.Post {
+	store := ctx.KVStore(k.storeKey)
+	iterator := store.Iterator(types.KeyPrefixPost, nil)
+
+	var posts []types.Post
+
+	defer iterator.Close()
+	for ; iterator.Valid(); iterator.Next() {
+		var object types.Post
+		k.cdc.MustUnmarshalBinaryBare(iterator.Value(), &object)
+		posts = append(posts, object)
+	}
+
+	return posts
+
+}

--- a/x/curating/keeper/querier.go
+++ b/x/curating/keeper/querier.go
@@ -1,6 +1,9 @@
 package keeper
 
 import (
+	"fmt"
+	"strconv"
+
 	abci "github.com/tendermint/tendermint/abci/types"
 
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -19,7 +22,10 @@ func NewQuerier(k Keeper) sdk.Querier {
 		switch path[0] {
 		case types.QueryParams:
 			return queryParams(ctx, k)
-			// TODO: Put the modules query routes
+		case types.QueryPost:
+			return queryPost(ctx, path[1:], req, k)
+		case types.QueryPosts:
+			return queryPosts(ctx, k)
 		default:
 			return nil, sdkerrors.Wrap(sdkerrors.ErrUnknownRequest, "unknown curating query endpoint")
 		}
@@ -37,5 +43,31 @@ func queryParams(ctx sdk.Context, k Keeper) ([]byte, error) {
 	return res, nil
 }
 
-// TODO: Add the modules query functions
-// They will be similar to the above one: queryParams()
+func queryPost(ctx sdk.Context, path []string, req abci.RequestQuery, k Keeper) ([]byte, error) {
+	i64, _ := strconv.ParseUint(path[0], 10, 32)
+	vendorID := uint32(i64)
+	postID := path[1]
+
+	post, _, err := k.GetPost(ctx, vendorID, postID)
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	res, err := codec.MarshalJSONIndent(types.ModuleCdc, post)
+	if err != nil {
+		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+	}
+
+	return res, nil
+}
+
+func queryPosts(ctx sdk.Context, k Keeper) ([]byte, error) {
+	posts := k.GetPosts(ctx)
+
+	res, err := codec.MarshalJSONIndent(types.ModuleCdc, posts)
+	if err != nil {
+		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
+	}
+
+	return res, nil
+}

--- a/x/curating/keeper/querier.go
+++ b/x/curating/keeper/querier.go
@@ -12,10 +12,6 @@ import (
 	"github.com/public-awesome/stakebird/x/curating/types"
 )
 
-// [TODO]
-// https://github.com/public-awesome/stakebird/issues/57
-// https://github.com/public-awesome/stakebird/issues/58
-
 // NewQuerier creates a new querier for curating clients.
 func NewQuerier(k Keeper) sdk.Querier {
 	return func(ctx sdk.Context, path []string, req abci.RequestQuery) ([]byte, error) {
@@ -24,8 +20,8 @@ func NewQuerier(k Keeper) sdk.Querier {
 			return queryParams(ctx, k)
 		case types.QueryPost:
 			return queryPost(ctx, path[1:], req, k)
-		case types.QueryPosts:
-			return queryPosts(ctx, k)
+		case types.QueryUpvotes:
+			return queryUpvotes(ctx, path[1:], req, k)
 		default:
 			return nil, sdkerrors.Wrap(sdkerrors.ErrUnknownRequest, "unknown curating query endpoint")
 		}
@@ -61,10 +57,19 @@ func queryPost(ctx sdk.Context, path []string, req abci.RequestQuery, k Keeper) 
 	return res, nil
 }
 
-func queryPosts(ctx sdk.Context, k Keeper) ([]byte, error) {
-	posts := k.GetPosts(ctx)
+func queryUpvotes(ctx sdk.Context, path []string, req abci.RequestQuery, k Keeper) ([]byte, error) {
+	i64, _ := strconv.ParseUint(path[0], 10, 32)
+	vendorID := uint32(i64)
+	var upvotes []types.Upvote
 
-	res, err := codec.MarshalJSONIndent(types.ModuleCdc, posts)
+	postID := path[1]
+	post, _, _ := k.GetPost(ctx, vendorID, postID)
+	k.IterateUpvotes(ctx, vendorID, post.PostIDHash, func(upvote types.Upvote) (stop bool) {
+		upvotes = append(upvotes, upvote)
+		return false
+	})
+
+	res, err := codec.MarshalJSONIndent(types.ModuleCdc, upvotes)
 	if err != nil {
 		return nil, sdkerrors.Wrap(sdkerrors.ErrJSONMarshal, err.Error())
 	}

--- a/x/curating/keeper/upvote.go
+++ b/x/curating/keeper/upvote.go
@@ -131,3 +131,22 @@ func (k Keeper) IterateUpvotes(
 		}
 	}
 }
+
+// IterateUpvotes performs a callback function for each upvote
+func (k Keeper) IterateAllUpvotes(
+	ctx sdk.Context, vendorID uint32, cb func(upvote types.Upvote) (stop bool)) {
+
+	store := ctx.KVStore(k.storeKey)
+
+	// iterator over upvoters on a post
+	it := sdk.KVStorePrefixIterator(store, nil)
+	defer it.Close()
+
+	for ; it.Valid(); it.Next() {
+		var upvote types.Upvote
+		k.cdc.MustUnmarshalBinaryBare(it.Value(), &upvote)
+		if cb(upvote) {
+			break
+		}
+	}
+}

--- a/x/curating/types/querier.go
+++ b/x/curating/types/querier.go
@@ -2,9 +2,9 @@ package types
 
 // Query endpoints supported by the curating querier
 const (
-	QueryParams = "parameters"
-	QueryPost   = "post"
-	QueryPosts  = "posts"
+	QueryParams  = "parameters"
+	QueryPost    = "post"
+	QueryUpvotes = "upvotes"
 )
 
 /*

--- a/x/curating/types/querier.go
+++ b/x/curating/types/querier.go
@@ -3,6 +3,8 @@ package types
 // Query endpoints supported by the curating querier
 const (
 	QueryParams = "parameters"
+	QueryPost   = "post"
+	QueryPosts  = "posts"
 )
 
 /*


### PR DESCRIPTION
Closes #57 
Closes #58 

As we discussed in Slack, we don't need to query for ALL posts or ALL upvotes as there might be tons of those.