### PR TITLE
Prevent divide by zero error, closes #130

### DIFF
--- a/x/curating/quadratic.go
+++ b/x/curating/quadratic.go
@@ -39,10 +39,16 @@ func (q QVFData) MatchPool() sdk.Dec {
 
 // VoterReward returns the distribution for a voter
 func (q QVFData) VoterReward() sdk.Int {
+	if q.VoterCount == 0 {
+		return sdk.ZeroInt()
+	}
 	return q.VotingPool.QuoRaw(q.VoterCount)
 }
 
 // MatchReward returns the funding match for a voter
 func (q QVFData) MatchReward() sdk.Dec {
+	if q.VoterCount == 0 {
+		return sdk.ZeroDec()
+	}
 	return q.MatchPool().QuoInt64(q.VoterCount)
 }

--- a/x/curating/quadratic_test.go
+++ b/x/curating/quadratic_test.go
@@ -27,3 +27,14 @@ func TestQVF(t *testing.T) {
 	require.Equal(t, "5", q.VoterReward().String())
 	require.Equal(t, "3.000000000000000000", q.MatchReward().String())
 }
+
+func TestQVFZeroVotes(t *testing.T) {
+	q := curating.NewQVFData()
+
+	require.Equal(t, int64(0), q.VoterCount)
+	require.Equal(t, "0", q.VotingPool.String())
+	require.Equal(t, "0.000000000000000000", q.RootSum.String())
+	require.Equal(t, "0.000000000000000000", q.MatchPool().String())
+	require.Equal(t, "0", q.VoterReward().String())
+	require.Equal(t, "0.000000000000000000", q.MatchReward().String())
+}


### PR DESCRIPTION
If a post has zero votes, a `Division By Zero` error is currently thrown, this checks for that edge case in the `VoterReward` and `MatchReward` functions.