### PR TITLE
Changed default curation window to 10 mins

### DIFF
--- a/x/curating/types/params.go
+++ b/x/curating/types/params.go
@@ -13,7 +13,7 @@ import (
 // Default parameter namespace
 const (
 	DefaultParamspace     string        = ModuleName
-	DefaultCurationWindow time.Duration = time.Hour * 24 * 3
+	DefaultCurationWindow time.Duration = time.Minute * 10
 	DefaultMaxNumVotes    uint32        = 5
 	DefaultMaxVendors     uint32        = 1
 )


### PR DESCRIPTION
This just makes local development much easier. The defaults will be set in the genesis file for testnets and mainnet anyway, not here.